### PR TITLE
Support node.js v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A require hook to compile CSS Modules on the fly",
   "main": "lib/index.js",
   "engines": {
-    "node": "^12.16.2"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@birdofpreyru Thank you for this publish, css-loader still support node.js v10. Do you mind to count the node.js v10 in?